### PR TITLE
Fix backup path saving

### DIFF
--- a/SysLog.Infraestructure/BackgroundServices/BackupService.cs
+++ b/SysLog.Infraestructure/BackgroundServices/BackupService.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System.IO;
 using SysLog.Domine.ModelDto;
-using SysLog.Repository.Model;
 using SysLog.Service.Interfaces;
 using SysLog.Service.Interfaces.Services;
 
@@ -40,10 +40,11 @@ public class BackupService : BackgroundService
             
             var backupFileDto = new BackupFileDto()
             {
-                PathFile = path,
-                FileName = path
+                PathFile = Path.GetDirectoryName(path)!,
+                FileName = Path.GetFileName(path)
             };
            await _backupFileService.AddAsync(backupFileDto);
+           await _backupFileService.SaveAsync();
         }
         
     }


### PR DESCRIPTION
## Summary
- remove unused namespace in BackupService
- ensure backup path and file name are saved separately

## Testing
- `dotnet build SysLog.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d5bbb59483269a26c872fad2ef1a