### PR TITLE
Add paginated logs API

### DIFF
--- a/SysLog.Api/Apis/LogApi.cs
+++ b/SysLog.Api/Apis/LogApi.cs
@@ -30,4 +30,11 @@ public class LogApi : ControllerBase
 
         return Ok(result);
     }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<LogDto>>> GetPagedLogs([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+    {
+        var logs = await _logService.GetPagedLogsAsync(page, pageSize);
+        return Ok(logs);
+    }
 }

--- a/SysLog.Application/Interfaces/Services/ILogService.cs
+++ b/SysLog.Application/Interfaces/Services/ILogService.cs
@@ -6,4 +6,5 @@ public interface ILogService : IServiceDto<LogDto>
 {
     public Task<LogDto> GetLastLogAsync();
     Task RemoveAllLogsAsync();
+    Task<IEnumerable<LogDto>> GetPagedLogsAsync(int page, int pageSize);
 }

--- a/SysLog.Application/Services/LogService.cs
+++ b/SysLog.Application/Services/LogService.cs
@@ -19,4 +19,10 @@ public class LogService(ILogRepository repository) : Service<LogDto,Log>(reposit
     {
         return repository.RemoveAllLogsAsync();
     }
+
+    public async Task<IEnumerable<LogDto>> GetPagedLogsAsync(int page, int pageSize)
+    {
+        var entities = await repository.GetPagedLogsAsync(page, pageSize);
+        return entities.Select(MapperTo.Map<Log, LogDto>);
+    }
 }

--- a/SysLog.Domain/Repositories/ILogRepository.cs
+++ b/SysLog.Domain/Repositories/ILogRepository.cs
@@ -6,4 +6,5 @@ public interface ILogRepository : IRepository<Log>
 {
     public Task<Log> getLastLogAsync();
     Task RemoveAllLogsAsync();
+    Task<IEnumerable<Log>> GetPagedLogsAsync(int page, int pageSize);
 }

--- a/SysLog.Infraestructure/Repositories/LogRepository.cs
+++ b/SysLog.Infraestructure/Repositories/LogRepository.cs
@@ -20,4 +20,18 @@ public class LogRepository(ApplicationDbContext dbContext)  : Repository<Log>(db
         _dbContext.Set<Log>().RemoveRange(allLogs);
         await _dbContext.SaveChangesAsync();
     }
+
+    public async Task<IEnumerable<Log>> GetPagedLogsAsync(int page, int pageSize)
+    {
+        if (page < 1)
+            page = 1;
+        if (pageSize < 1)
+            pageSize = 1;
+
+        return await _dbContext.Set<Log>()
+            .OrderByDescending(log => log.DateTime)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- add paged retrieval method to `ILogRepository`
- expose pagination operation via `ILogService`
- implement pagination in `LogService` and `LogRepository`
- provide new endpoint `GET /api/Log` for paginated logs

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e605e67883269c9550214582aefd