### PR TITLE
Fix BackupFileService using specialized repo

### DIFF
--- a/SysLog.Application/Services/BackupFileService.cs
+++ b/SysLog.Application/Services/BackupFileService.cs
@@ -5,10 +5,10 @@ using SysLog.Service.Interfaces.Services;
 
 namespace SysLog.Service.Services;
 
-public class BackupFileService(IRepository<BackupFile> repository) : Service<BackupFileDto,BackupFile>(repository),IBackupFileService
+public class BackupFileService(IBackupFileRepository repository) : Service<BackupFileDto,BackupFile>(repository),IBackupFileService
 {
     public int GetLastBackupFileDayTime()
     {
-        return 1;
+        return repository.GetLastBackupFileDayTime();
     }
 }


### PR DESCRIPTION
## Summary
- use `IBackupFileRepository` in `BackupFileService`
- delegate `GetLastBackupFileDayTime` to the repository

## Testing
- `dotnet build SysLog.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae40503e88326addfb4f179f822c1