### PR TITLE
Fix DTO cycles and default JSON references

### DIFF
--- a/SysLog.Api/Program.cs
+++ b/SysLog.Api/Program.cs
@@ -35,7 +35,7 @@ builder.Services
     .AddControllers()
     .AddJsonOptions(options =>
     {
-        options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.Preserve;
+        options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
     });
 var sysLogCs = builder.Configuration.GetConnectionString("SysLogDb");
 var backupCs = builder.Configuration.GetConnectionString("BackupDb");

--- a/SysLog.Application/ModelDto/ActionDto.cs
+++ b/SysLog.Application/ModelDto/ActionDto.cs
@@ -3,6 +3,4 @@ namespace SysLog.Domine.ModelDto;
 public class ActionDto
 {
     public string AcctionName { get; set; }
-    public LogDto Log { get; set; }
-    public int LogId { get; set; }
 }

--- a/SysLog.Application/ModelDto/InterfaceDto.cs
+++ b/SysLog.Application/ModelDto/InterfaceDto.cs
@@ -3,7 +3,4 @@ namespace SysLog.Domine.ModelDto;
 public class InterfaceDto
 {
     public string Name { get; set; }
-    
-    public LogDto Log { get; set; }
-    public int LogId { get; set; }
 }

--- a/SysLog.Application/ModelDto/LogTypeDto.cs
+++ b/SysLog.Application/ModelDto/LogTypeDto.cs
@@ -4,7 +4,4 @@ public class LogTypeDto
 {
     public string TypeName{ get; set; }
     public SignatureDto? Signature { get; set; }
-    
-    public LogDto Log { get; set; }
-    public int LogId { get; set; }
 }

--- a/SysLog.Application/ModelDto/ProtocolDto.cs
+++ b/SysLog.Application/ModelDto/ProtocolDto.cs
@@ -3,7 +3,4 @@ namespace SysLog.Domine.ModelDto;
 public class ProtocolDto
 {
     public string Name { get; set; }
-    
-    public LogDto Log { get; set; }
-    public int LogId { get; set; }
 }

--- a/SysLog.Application/ModelDto/SignatureDto.cs
+++ b/SysLog.Application/ModelDto/SignatureDto.cs
@@ -3,7 +3,4 @@ namespace SysLog.Domine.ModelDto;
 public class SignatureDto
 {
     public string Message { get; set; }
- 
-    public LogTypeDto LogType { get; set; }
-    public int LogTypeId { get; set; }
 }


### PR DESCRIPTION
## Summary
- remove back-references in DTO models to eliminate circular references
- switch JSON serialization to use `ReferenceHandler.IgnoreCycles`

## Testing
- ❌ `dotnet build --no-restore` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684af248c6888326a95cdfd4d70185b7