### PR TITLE
Handle truncated JSON logs

### DIFF
--- a/SysLog.Infraestructure/Utilities/Parsing/JsonLogParseStrategy.cs
+++ b/SysLog.Infraestructure/Utilities/Parsing/JsonLogParseStrategy.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using SysLog.Domine.Builder;
 using SysLog.Domine.Interfaces;
 using SysLog.Repository.Model;
@@ -29,8 +30,7 @@ public class JsonLogParseStrategy : ILogParseStrategy
         }
         catch (JsonException)
         {
-            // Not valid JSON, let other strategies try to parse
-            return false;
+            return TryParsePartial(jsonPart, out log);
         }
 
         string timestamp = root.GetProperty("timestamp").GetString()!;
@@ -84,7 +84,62 @@ public class JsonLogParseStrategy : ILogParseStrategy
                    (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) ||
                    (bytes[0] == 192 && bytes[1] == 168);
         }
-
+        
         return false;
+    }
+
+    private static bool TryParsePartial(string jsonPart, out Log log)
+    {
+        log = null!;
+
+        string Extract(string name)
+        {
+            var match = Regex.Match(jsonPart, $"\"{name}\":\"([^\"]+)\"");
+            return match.Success ? match.Groups[1].Value : string.Empty;
+        }
+
+        string timestamp = Extract("timestamp");
+        string inIface = Extract("in_iface");
+        string srcIp = Extract("src_ip");
+        string destIp = Extract("dest_ip");
+        string protocol = Extract("proto");
+        string eventType = Extract("event_type");
+
+        if (string.IsNullOrEmpty(timestamp) || string.IsNullOrEmpty(inIface) ||
+            string.IsNullOrEmpty(srcIp) || string.IsNullOrEmpty(destIp) ||
+            string.IsNullOrEmpty(protocol) || string.IsNullOrEmpty(eventType))
+        {
+            return false;
+        }
+
+        DateTime dateTime;
+        if (!DateTime.TryParseExact(timestamp, "yyyy-MM-ddTHH:mm:ss.fffffffzzz",
+                CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal,
+                out dateTime))
+        {
+            return false;
+        }
+        dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+
+        string action = IsPrivate(srcIp) ? "out" : "in";
+
+        string? signature = null;
+        var sigMatch = Regex.Match(jsonPart, "\"signature\":\"([^\"]+)\"");
+        if (sigMatch.Success)
+            signature = sigMatch.Groups[1].Value;
+
+        log = new Log
+        {
+            LogType = new LogTypeBuilder().WithType(eventType)
+                .WhitSignature(signature).Build(),
+            Interface = new Interface { Name = inIface },
+            Protocol = new Protocol { Name = protocol },
+            IpOut = srcIp,
+            IpDestiny = destIp,
+            Action = new Action { AcctionName = action },
+            DateTime = dateTime
+        };
+
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- improve JSON parser to fallback to regex when JSON is incomplete

## Testing
- `dotnet build SysLog.sln -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af4ad8d5083268d8db414aba8e4f2