### PR TITLE
Fix log fetch to include relations

### DIFF
--- a/SysLog.Infraestructure/Repositories/LogRepository.cs
+++ b/SysLog.Infraestructure/Repositories/LogRepository.cs
@@ -10,6 +10,11 @@ public class LogRepository(ApplicationDbContext dbContext)  : Repository<Log>(db
     public async Task<Log> getLastLogAsync()
     {
         return await _dbContext.Set<Log>()
+            .Include(log => log.Protocol)
+            .Include(log => log.Action)
+            .Include(log => log.Interface)
+            .Include(log => log.LogType)
+                .ThenInclude(lt => lt.Signature)
             .OrderByDescending(log => log.DateTime)
             .FirstOrDefaultAsync();
     }
@@ -36,6 +41,7 @@ public class LogRepository(ApplicationDbContext dbContext)  : Repository<Log>(db
             .Include(log => log.Action)
             .Include(log => log.Interface)
             .Include(log => log.LogType)
+                .ThenInclude(lt => lt.Signature)
             .ToListAsync();
     }
 }


### PR DESCRIPTION
## Summary
- include navigation properties when reading logs

## Testing
- `dotnet build SysLog.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b0590a254832682e82b1baf2839c3