### PR TITLE
Add cleanup for logs and related entities

### DIFF
--- a/SysLog.Application/Interfaces/Services/ILogService.cs
+++ b/SysLog.Application/Interfaces/Services/ILogService.cs
@@ -6,5 +6,9 @@ public interface ILogService : IServiceDto<LogDto>
 {
     public Task<LogDto> GetLastLogAsync();
     Task RemoveAllLogsAsync();
+    /// <summary>
+    /// Remove logs and their related properties after backup.
+    /// </summary>
+    Task RemoveAllLogsWithPropertiesAsync();
     Task<IEnumerable<LogDto>> GetPagedLogsAsync(int page, int pageSize);
 }

--- a/SysLog.Application/Services/LogService.cs
+++ b/SysLog.Application/Services/LogService.cs
@@ -24,6 +24,11 @@ public class LogService(ILogRepository repository) : Service<LogDto,Log>(reposit
         return repository.RemoveAllLogsAsync();
     }
 
+    public Task RemoveAllLogsWithPropertiesAsync()
+    {
+        return repository.RemoveAllLogsWithPropertiesAsync();
+    }
+
     public async Task<IEnumerable<LogDto>> GetPagedLogsAsync(int page, int pageSize)
     {
         var entities = await repository.GetPagedLogsAsync(page, pageSize);

--- a/SysLog.Domain/Interfaces/Repositories/ILogRepository.cs
+++ b/SysLog.Domain/Interfaces/Repositories/ILogRepository.cs
@@ -6,5 +6,9 @@ public interface ILogRepository : IRepository<Log>
 {
     public Task<Log> getLastLogAsync();
     Task RemoveAllLogsAsync();
+    /// <summary>
+    /// Remove all logs along with their related entities.
+    /// </summary>
+    Task RemoveAllLogsWithPropertiesAsync();
     Task<IEnumerable<Log>> GetPagedLogsAsync(int page, int pageSize);
 }

--- a/SysLog.Infraestructure/BackgroundServices/BackupService.cs
+++ b/SysLog.Infraestructure/BackgroundServices/BackupService.cs
@@ -65,8 +65,8 @@ public class BackupService : BackgroundService
                await _backupFileService.SaveAsync();
                _logger.LogInformation("Backup saved to {Path}", path);
                
-               await _logService.RemoveAllLogsAsync();
-               _logger.LogInformation("All Logs has been Deleted successfully");
+               await _logService.RemoveAllLogsWithPropertiesAsync();
+               _logger.LogInformation("All Logs and related entities have been Deleted successfully");
            }
            catch (Exception ex)
            {

--- a/SysLog.Infraestructure/Repositories/LogRepository.cs
+++ b/SysLog.Infraestructure/Repositories/LogRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
 using SysLog.Domine.Interfaces.Repositories;
 using SysLog.Repository.Data;
 using SysLog.Repository.Model;
@@ -23,6 +24,26 @@ public class LogRepository(ApplicationDbContext dbContext)  : Repository<Log>(db
     {
         var allLogs = await _dbContext.Set<Log>().ToListAsync();
         _dbContext.Set<Log>().RemoveRange(allLogs);
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task RemoveAllLogsWithPropertiesAsync()
+    {
+        var logs = await _dbContext.Set<Log>()
+            .Include(l => l.Protocol)
+            .Include(l => l.Action)
+            .Include(l => l.Interface)
+            .Include(l => l.LogType)
+                .ThenInclude(lt => lt.Signature)
+            .ToListAsync();
+
+        _dbContext.Set<Signature>().RemoveRange(logs.Select(l => l.LogType.Signature));
+        _dbContext.Set<LogType>().RemoveRange(logs.Select(l => l.LogType));
+        _dbContext.Set<Action>().RemoveRange(logs.Select(l => l.Action));
+        _dbContext.Set<Interface>().RemoveRange(logs.Select(l => l.Interface));
+        _dbContext.Set<Protocol>().RemoveRange(logs.Select(l => l.Protocol));
+        _dbContext.Set<Log>().RemoveRange(logs);
+
         await _dbContext.SaveChangesAsync();
     }
 


### PR DESCRIPTION
## Summary
- extend repository & service interfaces to support deleting logs with their related properties
- implement removal of logs and dependent entities
- invoke new cleanup logic from `BackupService`

## Testing
- `dotnet build SysLog.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b083820048326b8986105c6e6d408