### PR TITLE
Add syslogd parsing strategy

### DIFF
--- a/SysLog.Api/Program.cs
+++ b/SysLog.Api/Program.cs
@@ -60,6 +60,7 @@ builder.Services.AddScoped<ILogParseStrategy, JsonLogParseStrategy>();
 builder.Services.AddScoped<ILogParseStrategy, FilterLogParseStrategy>();
 builder.Services.AddScoped<ILogParseStrategy, CustomFilterLogParseStrategy>();
 builder.Services.AddScoped<ILogParseStrategy, CronLogParseStrategy>();
+builder.Services.AddScoped<ILogParseStrategy, SyslogdLogParseStrategy>();
 builder.Services.AddScoped<ILogParseStrategy, UnknownLogParseStrategy>();
 builder.Services.AddScoped<IJsonParser, LogParser>();
 builder.Services.AddScoped<IBackup,PostgreSqlServerBackup>();

--- a/SysLog.Infraestructure/Utilities/Parsing/SyslogdLogParseStrategy.cs
+++ b/SysLog.Infraestructure/Utilities/Parsing/SyslogdLogParseStrategy.cs
@@ -1,0 +1,46 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using SysLog.Domine.Builder;
+using SysLog.Domine.Interfaces;
+using SysLog.Repository.Model;
+using Action = SysLog.Repository.Model.Action;
+
+namespace SysLog.Repository.Utilities.Parsing;
+
+/// <summary>
+/// Parses basic syslogd messages like "syslogd: restart".
+/// </summary>
+public class SyslogdLogParseStrategy : ILogParseStrategy
+{
+    public bool TryParse(string logMessage, out Log log)
+    {
+        log = null!;
+        const string pattern = @"<\d+>([A-Za-z]+)\s+(\d+)\s+([\d:]+)\s+syslogd:\s+(.*)";
+        var match = Regex.Match(logMessage, pattern);
+        if (!match.Success)
+            return false;
+
+        string month = match.Groups[1].Value;
+        int day = int.Parse(match.Groups[2].Value);
+        string time = match.Groups[3].Value;
+        string message = match.Groups[4].Value;
+
+        var fullDate = $"{DateTime.UtcNow.Year} {month} {day} {time}";
+        DateTime dateTime = DateTime.ParseExact(fullDate, "yyyy MMM d HH:mm:ss",
+            CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+        dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+
+        log = new Log
+        {
+            LogType = new LogTypeBuilder().WithType("syslogd").Build(),
+            Interface = new Interface { Name = "N/A" },
+            Protocol = new Protocol { Name = "N/A" },
+            IpOut = "N/A",
+            IpDestiny = message,
+            Action = new Action { AcctionName = "N/A" },
+            DateTime = dateTime
+        };
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- parse `syslogd` restart messages with new `SyslogdLogParseStrategy`
- register the strategy in dependency injection

## Testing
- `dotnet build SysLog.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b07cad1cc8326ad5ee1b06abfad9d