### PR TITLE
Add helper scripts to run API and Blazor client together

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# SysLog
+
+This solution includes a Blazor WebAssembly client (`SysLog.Client`) and an API server (`SysLog.Api`).
+
+## Running both projects
+
+Use the provided helper script to start the API server and Blazor client together.
+
+On Unix-like systems:
+
+```bash
+./start_all.sh
+```
+
+On Windows PowerShell:
+
+```powershell
+./start_all.ps1
+```
+
+The script starts `SysLog.Api` in the background and then runs the Blazor client. When the client stops, the server process is terminated.
+

--- a/start_all.ps1
+++ b/start_all.ps1
@@ -1,0 +1,9 @@
+$server = Start-Process "dotnet" "run --project SysLog.Api" -PassThru
+try {
+    dotnet run --project SysLog.Client
+} finally {
+    if ($server -ne $null) {
+        Stop-Process -Id $server.Id
+    }
+}
+

--- a/start_all.sh
+++ b/start_all.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+# Start the API server in the background
+dotnet run --project SysLog.Api &
+server_pid=$!
+# Ensure the server is stopped when the script exits
+trap "kill $server_pid" EXIT
+
+# Run the Blazor client
+dotnet run --project SysLog.Client
+


### PR DESCRIPTION
## Summary
- add helper scripts to start the API server and Blazor client simultaneously
- document how to use the scripts

## Testing
- `dotnet build SysLog.sln --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b158866b08326a6cd3fe12c2491b7