### PR TITLE
Fix cookie auth in Blazor client

### DIFF
--- a/SysLog.Api/Program.cs
+++ b/SysLog.Api/Program.cs
@@ -52,8 +52,9 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy("BlazorClient", p => p
         .WithOrigins(
-            "https://localhost:5002",    
-            "http://localhost:5001")
+            "https://localhost:5002",
+            "http://localhost:5001",
+            "https://localhost:7182")
         .AllowAnyHeader()
         .AllowAnyMethod()
         .AllowCredentials());
@@ -134,6 +135,7 @@ app.UseRouting();
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.MapControllers();
 app.MapStaticAssets();
 
 app.Run();

--- a/SysLog.Client/Components/Topbar.razor
+++ b/SysLog.Client/Components/Topbar.razor
@@ -1,4 +1,6 @@
-﻿ <!-- Topbar -->
+﻿@using SysLog.Shared.ModelDto
+@using SysLog.Client.Services
+<!-- Topbar -->
                 <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
 
                     <!-- Sidebar Toggle (Topbar) -->
@@ -65,7 +67,7 @@
                         <li class="nav-item dropdown no-arrow">
                             <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button"
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                <span class="mr-2 d-none d-lg-inline text-gray-600 small">Douglas McGee</span>
+                                <span class="mr-2 d-none d-lg-inline text-gray-600 small">@_currentUser?.Username</span>
                                 <img class="img-profile rounded-circle"
                                     src="img/undraw_profile.svg">
                             </a>
@@ -96,3 +98,18 @@
 
                 </nav>
                 <!-- End of Topbar -->
+
+@code {
+    private CurrentUserDto? _currentUser;
+
+    [Inject] private AuthProvider AuthProvider { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        var result = await AuthProvider.GetCurrentUser();
+        if (result.IsSuccessful(out var user))
+        {
+            _currentUser = user;
+        }
+    }
+}

--- a/SysLog.Client/Pages/Home.razor
+++ b/SysLog.Client/Pages/Home.razor
@@ -36,8 +36,8 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var result = await _authProvider.GetAuthenticationStateAsync();
-        
+        var result = await _authProvider.GetCurrentUser();
+
         if (result.IsSuccessful(out var currentUser))
         {
             _isAuthenticated = currentUser.IsAuthenticated;

--- a/SysLog.Client/Program.cs
+++ b/SysLog.Client/Program.cs
@@ -19,8 +19,8 @@ builder.Services.AddScoped(sp => new HttpClient
 // Configurar autenticación
 builder.Services.AddOptions();
 builder.Services.AddAuthorizationCore();
-
-builder.Services.AddScoped<AuthProvider>();     
+builder.Services.AddScoped<AuthProvider>();
+builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<AuthProvider>());
 
 builder.Services.AddScoped<ClientSideApi>();
 builder.Services.AddScoped<LogService>();

--- a/SysLog.Client/Services/AuthProvider.cs
+++ b/SysLog.Client/Services/AuthProvider.cs
@@ -1,5 +1,4 @@
-// CustomAuthStateProvider.cs
-
+using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Authorization;
 using SysLog.Client.Client;
 using SysLog.Shared;
@@ -7,19 +6,38 @@ using SysLog.Shared.ModelDto;
 
 namespace SysLog.Client.Services;
 
-public class AuthProvider 
+public class AuthProvider : AuthenticationStateProvider
 {
     private readonly ClientSideApi _client;
+    private CurrentUserDto? _currentUser;
 
     public AuthProvider(ClientSideApi clientSideApi)
     {
         _client = clientSideApi;
     }
 
-    public async Task<TaskResult<CurrentUserDto>> GetAuthenticationStateAsync()
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
     {
-        var result = await _client.CallApiAsync<CurrentUserDto>("api/user/current-user","GET");
+        var identity = new ClaimsIdentity();
+        var result = await GetCurrentUser();
+        if (result.IsSuccessful(out var user) && user.IsAuthenticated)
+        {
+            _currentUser = user;
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, user.UserId),
+                new Claim(ClaimTypes.Name, user.Username),
+                new Claim(ClaimTypes.Email, user.Email)
+            };
+            identity = new ClaimsIdentity(claims, "serverAuth");
+        }
 
+        return new AuthenticationState(new ClaimsPrincipal(identity));
+    }
+
+    public async Task<TaskResult<CurrentUserDto>> GetCurrentUser()
+    {
+        var result = await _client.CallApiAsync<CurrentUserDto>("api/user/current-user", "GET");
         if (result.Value.IsSuccessful(out var user))
         {
             return TaskResult<CurrentUserDto>.FromData(user);
@@ -28,22 +46,24 @@ public class AuthProvider
         return TaskResult<CurrentUserDto>.FromFailure(result.Value.Message);
     }
 
-    
     public async Task<TaskResult> SignIn(string email, string password)
     {
         var dto = new UserLoginDto(email, password);
         var result = await _client.CallApiAsync<string>("api/user/login", "POST", dto);
 
-        if (!result.Value.IsSuccessful(out var _)) return TaskResult.FromFailure(result.Value.Message);
-        
+        if (!result.Value.IsSuccessful(out _))
+            return TaskResult.FromFailure(result.Value.Message);
+
+        NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
         return TaskResult.FromSuccess(result.Value.Message);
     }
-
 
     public async Task Logout()
     {
         await _client.CallApiAsync<string>("api/user/logout", "POST");
+        _currentUser = null;
+        NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
     }
 
+    public CurrentUserDto? CurrentUser => _currentUser;
 }
-


### PR DESCRIPTION
## Summary
- register controllers and add missing CORS origin
- implement `AuthenticationStateProvider`
- fetch current user in Topbar
- use new auth provider in Program and Home page

## Testing
- `dotnet build SysLog.sln -c Release` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68516f5166708326ac4512f1097b5196