### PR TITLE
Fix CurrentUserDto and authentication details

### DIFF
--- a/SysLog.Api/Controller/UserController.cs
+++ b/SysLog.Api/Controller/UserController.cs
@@ -69,12 +69,15 @@ public class UserController : ControllerBase
     [HttpGet("me")]
     public IResult GetCurrentUser()
     {
-        
+
         return Results.Ok(new
         {
+            userId = User.FindFirstValue(ClaimTypes.NameIdentifier),
+            username = User.Identity?.Name,
+            email = User.FindFirstValue(ClaimTypes.Email),
             isAuthenticated = User.Identity?.IsAuthenticated ?? false,
             claims = User.Claims.Select(c => new { c.Type, c.Value })
         });
-        
+
     }
 }

--- a/SysLog.Client/Services/AuthProvider.cs
+++ b/SysLog.Client/Services/AuthProvider.cs
@@ -37,7 +37,7 @@ public class AuthProvider : AuthenticationStateProvider
 
     public async Task<TaskResult<CurrentUserDto>> GetCurrentUser()
     {
-        var result = await _client.CallApiAsync<CurrentUserDto>("api/user/current-user", "GET");
+        var result = await _client.CallApiAsync<CurrentUserDto>("api/user/me", "GET");
         if (result.Value.IsSuccessful(out var user))
         {
             return TaskResult<CurrentUserDto>.FromData(user);

--- a/SysLog.Shared/ModelDto/CurrentUserDto.cs
+++ b/SysLog.Shared/ModelDto/CurrentUserDto.cs
@@ -2,6 +2,9 @@ namespace SysLog.Shared.ModelDto;
 
 public sealed class CurrentUserDto
 {
+    public string UserId { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
     public bool IsAuthenticated { get; set; }
     public IEnumerable<ClaimDto> Claims { get; set; } = Enumerable.Empty<ClaimDto>();
 }


### PR DESCRIPTION
## Summary
- add `UserId`, `Username` and `Email` fields to `CurrentUserDto`
- expose these details from the `UserController` `me` endpoint
- call the correct endpoint in `AuthProvider`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517702f5008326bf28655a46164f52