### PR TITLE
Fix JSON parsing error

### DIFF
--- a/SysLog.Client/Client/ClientSideApi.cs
+++ b/SysLog.Client/Client/ClientSideApi.cs
@@ -53,10 +53,14 @@ public class ClientSideApi
             response.EnsureSuccessStatusCode();
 
             var responseContent = await response.Content.ReadAsStringAsync();
-            if(string.IsNullOrEmpty(responseContent)) 
-                return TaskResult<TResponse>.FromFailure("No data available", 404); 
-            
-            TResponse? responseObject = JsonSerializer.Deserialize<TResponse>(responseContent);
+            if(string.IsNullOrEmpty(responseContent))
+                return TaskResult<TResponse>.FromFailure("No data available", 404);
+
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+            TResponse? responseObject = JsonSerializer.Deserialize<TResponse>(responseContent, options);
             return TaskResult<TResponse>.FromData(responseObject);
         }
         catch (JsonException jsonException)


### PR DESCRIPTION
## Summary
- use case-insensitive JSON deserialization in ClientSideApi

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517f2a12e4832682d7be55a4b09fbe