### PR TITLE
Fix login failure and redirect after registration

### DIFF
--- a/SysLog.Api/Controller/UserController.cs
+++ b/SysLog.Api/Controller/UserController.cs
@@ -27,14 +27,15 @@ public class UserController : ControllerBase
     [HttpPost("login")]
     public async Task<IResult> Authenticate([FromBody] UserLoginDto userLoginDto)
     {
-        var user = _userManager.Users.FirstOrDefault(u=>u.Email == userLoginDto.Email);
+        var user = _userManager.Users.FirstOrDefault(u => u.Email == userLoginDto.Email);
         if (user is not null)
         {
             var result = await _signInManager.PasswordSignInAsync(user, userLoginDto.Password, true, false);
-            if(result.Succeeded)
+            if (result.Succeeded)
                 return Results.Ok("Signed In");
         }
-        return Results.BadRequest(400);
+
+        return Results.BadRequest("Invalid credentials");
     }
 
     [AllowAnonymous]

--- a/SysLog.Client/Client/ClientSideApi.cs
+++ b/SysLog.Client/Client/ClientSideApi.cs
@@ -50,16 +50,25 @@ public class ClientSideApi
 
             var response = await Client.SendAsync(request);
 
-            response.EnsureSuccessStatusCode();
-
             var responseContent = await response.Content.ReadAsStringAsync();
-            if(string.IsNullOrEmpty(responseContent))
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var message = string.IsNullOrWhiteSpace(responseContent)
+                    ? response.ReasonPhrase
+                    : responseContent;
+
+                return TaskResult<TResponse>.FromFailure(message ?? "Error", (int)response.StatusCode);
+            }
+
+            if (string.IsNullOrEmpty(responseContent))
                 return TaskResult<TResponse>.FromFailure("No data available", 404);
 
             var options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             };
+
             TResponse? responseObject = JsonSerializer.Deserialize<TResponse>(responseContent, options);
             return TaskResult<TResponse>.FromData(responseObject);
         }

--- a/SysLog.Client/Pages/RegisterUser.razor
+++ b/SysLog.Client/Pages/RegisterUser.razor
@@ -61,8 +61,8 @@
     private async Task Register()
     {
         var result = await _authService.SignUp(_user.Username, _user.Email, _user.Password);
-        if(result.Success)
-            _navigationManager.NavigateTo("/",forceLoad:false,replace:true);
+        if (result.Success)
+            _navigationManager.NavigateTo("/login", forceLoad: false, replace: true);
     }
 
 }


### PR DESCRIPTION
## Summary
- improve login API error message
- handle non-success responses in the client API wrapper
- redirect newly registered users to the login page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685193adac308326a432d39d2ef2ea45