### PR TITLE
Improve login and register UX

### DIFF
--- a/SysLog.Client/Pages/Login.razor
+++ b/SysLog.Client/Pages/Login.razor
@@ -5,6 +5,8 @@
 @using SysLog.Client.Utility
 @using Blazored.FluentValidation
 @using FluentValidation
+@using System.Linq.Expressions
+@using Microsoft.AspNetCore.Components.Forms
 
 <div class="container">
     <!-- Outer Row -->
@@ -19,17 +21,17 @@
                                 <div class="text-center">
                                     <h1 class="h4 text-gray-900 mb-4">Welcome Back!</h1>
                                 </div>
-                                <EditForm Model="_userLoginModel" OnValidSubmit="HandleLogin" class="user">
+                                <EditForm EditContext="_editContext" OnValidSubmit="HandleLogin" class="user">
                                     <FluentValidationValidator @ref="_loginValidator"/>
                                     <div class="form-group">
-                                        <InputText @bind-Value="_userLoginModel.Email" type="email" class="form-control form-control-user"
+                                        <InputText @bind-Value="_userLoginModel.Email" type="email" class="@GetInputClass(() => _userLoginModel.Email)"
                                                    id="exampleInputEmail" aria-describedby="emailHelp"
                                                    placeholder="Enter Email Address...">
                                         </InputText>
                                         <ValidationMessage For="@(() => _userLoginModel.Email)"/>
                                     </div>
                                     <div class="form-group">
-                                        <InputText @bind-Value="_userLoginModel.Password" type="password" class="form-control form-control-user"
+                                        <InputText @bind-Value="_userLoginModel.Password" type="password" class="@GetInputClass(() => _userLoginModel.Password)"
                                                    id="exampleInputPassword" placeholder="Password">
                                         </InputText>
                                         <ValidationMessage For="@(() => _userLoginModel.Password)"/>
@@ -65,11 +67,28 @@
     private UserLoginModel _userLoginModel { get; } = new();
     private TaskResult _result { get; set; } = new();
     private FluentValidationValidator? _loginValidator;
+    private EditContext _editContext;
 
     [Inject] private NavigationManager _navigationManager { get; set; }
     [Inject] private AuthService _authService { get; set; }
     
     
+    protected override void OnInitialized()
+    {
+        _editContext = new EditContext(_userLoginModel);
+    }
+
+    private string GetInputClass(Expression<Func<object>> accessor)
+    {
+        var field = FieldIdentifier.Create(accessor);
+        var hasError = _editContext.GetValidationMessages(field).Any();
+        if (!hasError && _showAlert && !_result.Success)
+        {
+            hasError = true;
+        }
+        return hasError ? "form-control form-control-user is-invalid" : "form-control form-control-user";
+    }
+
     private async Task HandleLogin()
     {
         if (await _loginValidator.ValidateAsync())
@@ -78,9 +97,13 @@
             _result = result;
             if (result.Success)
             {
+                _showAlert = false;
                 _navigationManager.NavigateTo("/");
             }
-            _showAlert = false;
+            else
+            {
+                _showAlert = true;
+            }
         }
     }
 

--- a/SysLog.Client/Pages/RegisterUser.razor
+++ b/SysLog.Client/Pages/RegisterUser.razor
@@ -4,6 +4,8 @@
 @using SysLog.Client.Utility
 @using Blazored.FluentValidation
 @using SysLog.Client.Models
+@using Microsoft.AspNetCore.Components.Forms
+@using System.Linq.Expressions
 
 @inject AuthService _authService
 @inject NavigationManager _navigationManager
@@ -19,20 +21,20 @@
                                 <div class="text-center">
                                     <h1 class="h4 text-gray-900 mb-4">Create an Account!</h1>
                                 </div>
-                                <EditForm class="user" Model="_user" OnValidSubmit="Register">
+                                <EditForm class="user" EditContext="_editContext" OnValidSubmit="Register">
                                     <FluentValidationValidator @ref="_fluentValidationValidator"/>
                                     <div class="form-group">
-                                        <InputText @bind-Value="_user.Username" class="form-control form-control-user" id="exampleFirstName"
+                                        <InputText @bind-Value="_user.Username" class="@GetInputClass(() => _user.Username)" id="exampleFirstName"
                                                    placeholder="Username"/>
                                         <ValidationMessage For="@(() => _user.Username)"/>
                                     </div>
                                     <div class="form-group">
-                                        <InputText @bind-Value="_user.Email" type="email" class="form-control form-control-user" id="exampleInputEmail"
+                                        <InputText @bind-Value="_user.Email" type="email" class="@GetInputClass(() => _user.Email)" id="exampleInputEmail"
                                                    placeholder="Email Address"/>
                                         <ValidationMessage For="@(() => _user.Email)"/>
                                     </div>
                                     <div class="form-group">
-                                        <InputText @bind-Value="_user.Password" type="password" class="form-control form-control-user"
+                                        <InputText @bind-Value="_user.Password" type="password" class="@GetInputClass(() => _user.Password)"
                                                    id="exampleInputPassword" placeholder="Password"/>
                                         <ValidationMessage For="@(() => _user.Password)"/>
                                     </div>
@@ -59,17 +61,34 @@
 @code {
 
     private bool _showAlert = false;
-    private TaskResult _result;
+    private TaskResult _result = new();
     private FluentValidationValidator _fluentValidationValidator;
-    private UserRegisterModel _user { get; } = new();
+    private UserRegisterModel _user { get; set; } = new();
+    private EditContext _editContext;
 
+    protected override void OnInitialized()
+    {
+        _editContext = new EditContext(_user);
+    }
+
+    private string GetInputClass(Expression<Func<object>> accessor)
+    {
+        var field = FieldIdentifier.Create(accessor);
+        var hasError = _editContext.GetValidationMessages(field).Any();
+        if (!hasError && _showAlert && !_result.Success)
+        {
+            hasError = true;
+        }
+        return hasError ? "form-control form-control-user is-invalid" : "form-control form-control-user";
+    }
     private async Task Register()
     {
-        var result = await _authService.SignUp(_user.Username,_user.Email, _user.Password);
-        _result = result;
+        var result = await _authService.SignUp(_user.Username, _user.Email, _user.Password);
+        _result = result.Success ? TaskResult.FromSuccess("Usuario registrado con \u00E9xito") : result;
         if (result.Success)
         {
-            _navigationManager.NavigateTo("/",forceLoad:false,replace:true);
+            _user = new UserRegisterModel();
+            _editContext = new EditContext(_user);
         }
         _showAlert = true;
     }

--- a/SysLog.Client/Utility/Alert.razor
+++ b/SysLog.Client/Utility/Alert.razor
@@ -2,7 +2,7 @@
 
 @if (Visible)
 {
-    <div class="alert alert-@(Result.Success ? "primary" : "danger") alert-dismissible fade show" role="alert">
+    <div class="alert alert-@(Result.Success ? "success" : "danger") alert-dismissible fade show" role="alert">
         <button type="button" class="btn-close" aria-label="Close" @onclick="CloseAlert"></button>
         <strong>@(Result.Success ? "Éxito" : "Error"):</strong> @Result.Message
     </div>


### PR DESCRIPTION
## Summary
- enhance Alert component styling
- show field errors on login and registration forms
- display success message when user registers

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686531b5e6048326bcac11e9e4c6bb85