### PR TITLE
Implement loading backups by day

### DIFF
--- a/SysLog.Api/Controller/LogController.cs
+++ b/SysLog.Api/Controller/LogController.cs
@@ -5,6 +5,9 @@ using SysLog.Service.Mappers;
 using SysLog.Repository.Data;
 using SysLog.Repository.Repositories;
 using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Npgsql;
 using SysLog.Shared.ModelDto;
 
 
@@ -51,17 +54,17 @@ public class LogController : ControllerBase
     
 
     [HttpGet("days")]
-    public async Task<ActionResult<IEnumerable<BackupFileDto>>> GetAllsBackups()
+    public async Task<ActionResult<IEnumerable<string>>> GetAllsBackups()
     {
-        var list = await _backupFileService.GetAllAsync();
+        var list = await _backupFileService.GetAvailableDaysAsync();
         return Ok(list);
     }
 
     [HttpGet("backup")]
-    public async Task<ActionResult<IEnumerable<LogDto>>> GetBackupLogs([FromQuery] string day, [FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+    public async Task<IActionResult> LoadBackupDay([FromQuery] string day)
     {
-        var backup = await _backupFileService.FindByDateAsync(day);
-        if (backup == null)
+        var backups = await _backupFileService.FindAllByDateAsync(day);
+        if (backups == null || backups.Count == 0)
             return NotFound();
 
         var cs = _configuration.GetConnectionString("BackupDb")!;
@@ -72,35 +75,31 @@ public class LogController : ControllerBase
         using var ctx = new ApplicationDbContext(options);
         await ctx.Database.EnsureCreatedAsync();
 
-        await CleanupBackupAsync();
+        await CleanupBackupAsync(ctx);
 
-        var scriptPath = Path.Combine(backup.PathFile, backup.FileName);
-        var sql = await System.IO.File.ReadAllTextAsync(scriptPath);
-        await ctx.Database.ExecuteSqlRawAsync(sql);
+        foreach (var backup in backups.OrderBy(b => b.FileName))
+        {
+            var scriptPath = Path.Combine(backup.PathFile, backup.FileName);
+            var sql = await System.IO.File.ReadAllTextAsync(scriptPath);
+            await ctx.Database.ExecuteSqlRawAsync(sql);
+        }
 
-        var repo = new LogRepository(ctx);
-        var entities = await repo.GetPagedLogsAsync(page, pageSize);
-        var result = entities.Select(MapperLog.MapToLogDto);
-        return Ok(result);
+        return Ok();
     }
-
-    private async Task CleanupBackupAsync()
+    private async Task CleanupBackupAsync(ApplicationDbContext ctx)
     {
-        var cs = _configuration.GetConnectionString("BackupDb")!;
-        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseNpgsql(cs)
-            .Options;
-        using var ctx = new ApplicationDbContext(options);
-        const string sql = @"
-DROP TABLE IF EXISTS ""signatures"" CASCADE;
-DROP TABLE IF EXISTS ""logs_type"" CASCADE;
-DROP TABLE IF EXISTS ""actions"" CASCADE;
-DROP TABLE IF EXISTS ""interfaces"" CASCADE;
-DROP TABLE IF EXISTS ""protocols"" CASCADE;
-DROP TABLE IF EXISTS ""logs"" CASCADE;
-";
-        await ctx.Database.ExecuteSqlRawAsync(sql);
+        await using var conn = (Npgsql.NpgsqlConnection)ctx.Database.GetDbConnection();
+        await conn.OpenAsync();
+        var tables = new List<string>();
+        await using (var cmd = new Npgsql.NpgsqlCommand("SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE' AND table_name NOT IN ('backup_file','__EFMigrationsHistory');", conn))
+        await using (var reader = await cmd.ExecuteReaderAsync())
+        {
+            while (await reader.ReadAsync())
+                tables.Add(reader.GetString(0));
+        }
 
+        foreach (var table in tables)
+            await ctx.Database.ExecuteSqlRawAsync($"DROP TABLE IF EXISTS \"{table}\" CASCADE;");
     }
     
     

--- a/SysLog.Application/Interfaces/Services/IBackupFileService.cs
+++ b/SysLog.Application/Interfaces/Services/IBackupFileService.cs
@@ -7,4 +7,6 @@ public interface IBackupFileService : IServiceDto<BackupFileDto>
 {
     public int GetLastBackupFileDayTime();
     Task<BackupFileDto?> FindByDateAsync(string day);
+    Task<List<BackupFileDto>> FindAllByDateAsync(string dayPrefix);
+    Task<List<string>> GetAvailableDaysAsync();
 }

--- a/SysLog.Application/Services/BackupFileService.cs
+++ b/SysLog.Application/Services/BackupFileService.cs
@@ -19,4 +19,15 @@ public class BackupFileService(IBackupFileRepository repository) : Service<Backu
         var entity = await repository.FindByDateAsync(day);
         return MapperBackup.MapToDto(entity);
     }
+
+    public async Task<List<BackupFileDto>> FindAllByDateAsync(string dayPrefix)
+    {
+        var entities = await repository.FindAllByDateAsync(dayPrefix);
+        return entities.Select(MapperBackup.MapToDto).ToList();
+    }
+
+    public async Task<List<string>> GetAvailableDaysAsync()
+    {
+        return await repository.GetAvailableDaysAsync();
+    }
 }

--- a/SysLog.Client/Components/_ModalBackupFileDays.razor
+++ b/SysLog.Client/Components/_ModalBackupFileDays.razor
@@ -1,7 +1,6 @@
 @using System.Globalization
 @using System.IO
 @using System.Linq
-@using SysLog.Shared.ModelDto
 
 
 <button class="btn btn-primary" @onclick="OpenModal">Historial de Backups</button>
@@ -22,8 +21,8 @@
                             {
                                 <div class="col">
                                     <div class="backup-fecha-card text-center py-2 rounded"
-                                         @onclick="() => SelectDay(backup.FileName)">
-                                        @FormatDate(backup.FileName)
+                                         @onclick="() => SelectDay(backup)">
+                                        @FormatDate(backup)
                                     </div>
                                 </div>
                             }
@@ -43,7 +42,7 @@
 @code {
     
     [Parameter]
-    public List<BackupFileDto> BackupDays { get; set; } = new();
+    public List<string> BackupDays { get; set; } = new();
     
     private bool ShowModal { get; set; } = false;
     
@@ -59,18 +58,15 @@
         ShowModal = false;
     }
 
-    string FormatDate(string fileName)
+    string FormatDate(string day)
     {
-        var name = Path.GetFileNameWithoutExtension(fileName);
-        var datePart = name.Split('_').FirstOrDefault();
-        if (datePart != null &&
-            DateTime.TryParseExact(datePart.Substring(0, 8), "yyyyMMdd", CultureInfo.InvariantCulture,
+        if (DateTime.TryParseExact(day, "yyyyMMdd", CultureInfo.InvariantCulture,
                 DateTimeStyles.None, out var dt))
         {
             return dt.ToString("yyyy-MM-dd");
         }
 
-        return fileName;
+        return day;
     }
 }
 

--- a/SysLog.Client/Pages/Table.razor
+++ b/SysLog.Client/Pages/Table.razor
@@ -100,7 +100,7 @@ else
     private bool _isAuthenticated = false;
     private List<LogDto> _logs { get; set; } = [];
     private List<LogDto> _originalLogs { get; set; } = [];
-    private List<BackupFileDto> backupFileDtos = [];
+    private List<string> backupFileDtos = [];
     private bool _loading { get; set; }
     private int CurrentPage { get; set; } = 1;
     private int PageSize { get; set; } = 10;
@@ -198,8 +198,8 @@ else
         }
     }
 
-    private async Task SelectDay(string BackupName)
+    private async Task SelectDay(string day)
     {
-       await BackupService.GetSelectedBackup(BackupName);
+       await BackupService.GetSelectedBackup(day);
     }
 }

--- a/SysLog.Client/Services/BackupService.cs
+++ b/SysLog.Client/Services/BackupService.cs
@@ -13,20 +13,19 @@ public class BackupService
         _client = client;
     }
 
-    public async Task<TaskResult<List<BackupFileDto>>> GetAllBackups()
+    public async Task<TaskResult<List<string>>> GetAllBackups()
     {
-        var result = await _client.CallApiAsync<List<BackupFileDto>>("api/log/days", "GET");
+        var result = await _client.CallApiAsync<List<string>>("api/log/days", "GET");
         if (result != null && result.Value.IsSuccessful(out var backups))
         {
-            return TaskResult<List<BackupFileDto>>.FromData(backups);
+            return TaskResult<List<string>>.FromData(backups);
         }
-        return TaskResult<List<BackupFileDto>>.FromFailure(result?.Value.Message ?? "Error");
+        return TaskResult<List<string>>.FromFailure(result?.Value.Message ?? "Error");
     }
 
-    public async Task<TaskResult> GetSelectedBackup(string backupName)
+    public async Task<TaskResult> GetSelectedBackup(string day)
     {
-        // Placeholder: in the future this will load the script for the selected backup
-        await _client.CallApiAsync<string>($"api/log/backup?day={backupName}", "GET");
+        await _client.CallApiAsync<string>($"api/log/backup?day={day}", "GET");
         return TaskResult.SuccessResult;
     }
 }

--- a/SysLog.Domine/Interfaces/Repositories/IBackupFileRepository.cs
+++ b/SysLog.Domine/Interfaces/Repositories/IBackupFileRepository.cs
@@ -7,4 +7,6 @@ public interface IBackupFileRepository : IRepository<BackupFile>
 {
     public int GetLastBackupFileDayTime();
     Task<BackupFile?> FindByDateAsync(string day);
+    Task<List<BackupFile>> FindAllByDateAsync(string dayPrefix);
+    Task<List<string>> GetAvailableDaysAsync();
 }

--- a/SysLog.Infraestructure/Repositories/BackupFileRepository.cs
+++ b/SysLog.Infraestructure/Repositories/BackupFileRepository.cs
@@ -29,7 +29,21 @@ public class BackupFileRepository(BackupDbContext backupDbContext): Repository<B
     public async Task<BackupFile?> FindByDateAsync(string day)
     {
         return await backupDbContext.BackupFile
-            .FirstOrDefaultAsync(f => f.FileName.Length >= 8 && f.FileName.Substring(6, 2) == day);
+            .FirstOrDefaultAsync(f => f.FileName.StartsWith(day));
     }
 
+    public async Task<List<BackupFile>> FindAllByDateAsync(string dayPrefix)
+    {
+        return await backupDbContext.BackupFile
+            .Where(f => f.FileName.StartsWith(dayPrefix))
+            .ToListAsync();
+    }
+
+    public async Task<List<string>> GetAvailableDaysAsync()
+    {
+        return await backupDbContext.BackupFile
+            .Select(f => f.FileName.Substring(0, 8))
+            .Distinct()
+            .ToListAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- show unique backup days in the history modal
- load all scripts for a chosen day
- clear backup database tables before loading
- adjust services and repositories for new behavior

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686537ca96408326b6a0e362a961d71f