### PR TITLE
Move BackupLoaderService implementation to infrastructure

### DIFF
--- a/SysLog.Api/Program.cs
+++ b/SysLog.Api/Program.cs
@@ -18,7 +18,6 @@ using SysLog.Repository.Utilities;
 using SysLog.Repository.Utilities.Parsing;
 using SysLog.Service.Interfaces;
 using SysLog.Service.Interfaces.Services;
-using SysLog.Service.Services;
 using BackupService = SysLog.Client.Services.BackupService;
 using Log = Serilog.Log;
 using Microsoft.AspNetCore.Builder;

--- a/SysLog.Infraestructure/Service/BackupLoaderService.cs
+++ b/SysLog.Infraestructure/Service/BackupLoaderService.cs
@@ -7,7 +7,7 @@ using SysLog.Service.Interfaces.Services;
 using SysLog.Service.Mappers;
 using SysLog.Shared.ModelDto;
 
-namespace SysLog.Service.Services;
+namespace SysLog.Repository.Service;
 
 public class BackupLoaderService : IBackupLoaderService
 {


### PR DESCRIPTION
## Summary
- move `BackupLoaderService` from Application layer to Infrastructure
- adjust namespace imports in API

## Testing
- `dotnet build SysLog.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6b8975e88326b26ce1e82c6ddeaa