### PR TITLE
Fix backup loader SQL execution

### DIFF
--- a/SysLog.Infraestructure/Repositories/BackupLoaderRepository.cs
+++ b/SysLog.Infraestructure/Repositories/BackupLoaderRepository.cs
@@ -33,7 +33,9 @@ public class BackupLoaderRepository : IBackupLoaderRepository
         {
             var scriptPath = Path.Combine(backup.PathFile, backup.FileName);
             var sql = await File.ReadAllTextAsync(scriptPath);
-            await _backupContext.Database.ExecuteSqlRawAsync(sql);
+
+            await using var cmd = new NpgsqlCommand(sql, conn);
+            await cmd.ExecuteNonQueryAsync();
         }
 
         await conn.CloseAsync();


### PR DESCRIPTION
## Summary
- use `NpgsqlCommand` to execute SQL backup scripts

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d706cae048326afe79f8e57f386a2