### PR TITLE
Fix backup SQL execution without DbUp

### DIFF
--- a/SysLog.Infraestructure/Repositories/BackupLoaderRepository.cs
+++ b/SysLog.Infraestructure/Repositories/BackupLoaderRepository.cs
@@ -1,7 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
-using DbUp;
-using DbUp.Engine;
 using SysLog.Domine.Interfaces.Repositories;
 using SysLog.Repository.Data;
 using SysLog.Repository.Data.BackupDbContext;
@@ -53,19 +51,13 @@ public class BackupLoaderRepository : IBackupLoaderRepository
         return await GetLogsFromMainAsync();
     }
 
-    private static Task ExecuteSqlScriptAsync(NpgsqlConnection connection, string script)
+    private static async Task ExecuteSqlScriptAsync(NpgsqlConnection connection, string script)
     {
-        var upgrader = DeployChanges.To
-            .PostgresqlDatabase(connection.ConnectionString)
-            .WithScripts(new[] { new SqlScript("inline", script) })
-            .LogToConsole()
-            .Build();
-
-        var result = upgrader.PerformUpgrade();
-        if (!result.Successful)
-            throw result.Error!;
-
-        return Task.CompletedTask;
+        var sqlScript = new NpgsqlScript(script)
+        {
+            Connection = connection
+        };
+        await sqlScript.ExecuteAsync();
     }
 
     private async Task CleanupAsync(NpgsqlConnection conn)

--- a/SysLog.Infraestructure/SysLog.Infraestructure.csproj
+++ b/SysLog.Infraestructure/SysLog.Infraestructure.csproj
@@ -21,7 +21,6 @@
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.4.25258.110" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-      <PackageReference Include="DbUp.Postgresql" Version="5.3.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- remove DbUp references
- execute SQL scripts using `NpgsqlScript`
- drop DbUp package reference

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9e5f937083269778724769b1d4a9