### PR TITLE
Fix paginated log loading

### DIFF
--- a/SysLog.Api/Controller/LogController.cs
+++ b/SysLog.Api/Controller/LogController.cs
@@ -5,6 +5,7 @@ using SysLog.Repository.Repositories;
 using System.Collections.Generic;
 using System.Linq;
 using SysLog.Shared.ModelDto;
+using SysLog.Shared;
 
 
 
@@ -41,7 +42,7 @@ public class LogController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<LogDto>>> GetPagedLogs([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+    public async Task<ActionResult<PagedResult<LogDto>>> GetPagedLogs([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
     {
         var logs = await _logService.GetPagedLogsAsync(page, pageSize);
         return Ok(logs);

--- a/SysLog.Application/Interfaces/Services/ILogService.cs
+++ b/SysLog.Application/Interfaces/Services/ILogService.cs
@@ -1,4 +1,5 @@
 using SysLog.Shared.ModelDto;
+using SysLog.Shared;
 
 namespace SysLog.Service.Interfaces.Services;
 
@@ -10,5 +11,4 @@ public interface ILogService : IServiceDto<LogDto>
     /// Remove logs and their related properties after backup.
     /// </summary>
     Task RemoveAllLogsWithPropertiesAsync();
-    Task<IEnumerable<LogDto>> GetPagedLogsAsync(int page, int pageSize);
-}
+    Task<PagedResult<LogDto>> GetPagedLogsAsync(int page, int pageSize);}

--- a/SysLog.Application/Services/LogService.cs
+++ b/SysLog.Application/Services/LogService.cs
@@ -3,6 +3,7 @@ using SysLog.Repository.Model;
 using SysLog.Service.Interfaces.Services;
 using SysLog.Service.Mappers;
 using SysLog.Shared.ModelDto;
+using SysLog.Shared;
 
 namespace SysLog.Service.Services;
 
@@ -30,9 +31,14 @@ public class LogService(ILogRepository repository) : Service<LogDto,Log>(reposit
         return repository.RemoveAllLogsWithPropertiesAsync();
     }
 
-    public async Task<IEnumerable<LogDto>> GetPagedLogsAsync(int page, int pageSize)
+    public async Task<PagedResult<LogDto>> GetPagedLogsAsync(int page, int pageSize)
     {
-        var entities = await repository.GetPagedLogsAsync(page, pageSize);
-        return entities.Select(MapperLog.MapToLogDto);
-    }
-}
+        var result = await repository.GetPagedLogsAsync(page, pageSize);
+        return new PagedResult<LogDto>
+        {
+            Items = result.Items.Select(MapperLog.MapToLogDto).ToList(),
+            TotalItems = result.TotalItems,
+            Page = result.Page,
+            PageSize = result.PageSize
+        };
+    }}

--- a/SysLog.Client/Pages/Table.razor
+++ b/SysLog.Client/Pages/Table.razor
@@ -83,7 +83,7 @@
                         <button class="page-link @(@CurrentPage == 1 ? "disabled" : "")" @onclick="PreviousPage">Previous</button>
                     </li>
                     <li class="page-item">
-                        <button class="page-link @(@CurrentPage == _logs.Count ? "disabled" : "")" @onclick="NextPage">Next</button>
+                        <button class="page-link @(@CurrentPage >= TotalPages ? "disabled" : "")" @onclick="NextPage">Next</button>
                     </li>
                 </ul>
             </div>
@@ -101,6 +101,8 @@ else
     private bool _isAuthenticated = false;
     private List<LogDto> _logs { get; set; } = [];
     private List<LogDto> _originalLogs { get; set; } = [];
+    private int TotalLogs { get; set; }
+    private int TotalPages => (int)Math.Ceiling((double)TotalLogs / PageSize);
     private List<string> backupFileDtos = [];
     private bool _loading { get; set; }
     private int CurrentPage { get; set; } = 1;
@@ -133,10 +135,11 @@ else
         
         var result = await LogService.GetPagedLogs(CurrentPage, PageSize);
 
-        if (result.IsSuccessful(out var logDtos))
+        if (result.IsSuccessful(out var paged))
         {
-            _logs = logDtos;
-            _originalLogs = logDtos;
+            _logs = paged.Items;
+            _originalLogs = paged.Items;
+            TotalLogs = paged.TotalItems;
             _loading = false;
         }
         else
@@ -170,8 +173,11 @@ else
 
     private async Task NextPage()
     {
-        CurrentPage++;
-        await LoadLogs();
+        if (CurrentPage < TotalPages)
+        {
+            CurrentPage++;
+            await LoadLogs();
+        }
     }
 
     private void FilterLogs(string searchLog)
@@ -208,6 +214,8 @@ else
         {
             _logs = logs;
             _originalLogs = logs;
+            TotalLogs = logs.Count;
+            CurrentPage = 1;
         }
         else
         {
@@ -227,6 +235,8 @@ else
         {
             _logs = logs;
             _originalLogs = logs;
+            TotalLogs = logs.Count;
+            CurrentPage = 1;
         }
         else
         {
@@ -235,5 +245,4 @@ else
         }
         _loading = false;
         StateHasChanged();
-    }
-}
+    }}

--- a/SysLog.Client/Services/LogService.cs
+++ b/SysLog.Client/Services/LogService.cs
@@ -15,15 +15,15 @@ public class LogService
         Client = client;
     }
 
-    public async Task<TaskResult<List<LogDto>>> GetPagedLogs(int page, int pageSize)
+    public async Task<TaskResult<PagedResult<LogDto>>> GetPagedLogs(int page, int pageSize)
     {
-        var result = await Client.CallApiAsync<List<LogDto>>($"api/log?page={page}&pageSize={pageSize}", "GET");
+        var result = await Client.CallApiAsync<PagedResult<LogDto>>($"api/log?page={page}&pageSize={pageSize}", "GET");
 
-        if (result.Value.IsSuccessful(out var logDtos))
+        if (result.Value.IsSuccessful(out var data))
         {
-            return TaskResult<List<LogDto>>.FromData(logDtos);
+            return TaskResult<PagedResult<LogDto>>.FromData(data);
         }
-        return TaskResult<List<LogDto>>.FromFailure(result.Value.Message, result.Value.Code,result.Value.Details);
+        return TaskResult<PagedResult<LogDto>>.FromFailure(result.Value.Message, result.Value.Code, result.Value.Details);
     }
     
     

--- a/SysLog.Domine/Interfaces/Repositories/ILogRepository.cs
+++ b/SysLog.Domine/Interfaces/Repositories/ILogRepository.cs
@@ -1,4 +1,5 @@
 using SysLog.Repository.Model;
+using SysLog.Shared;
 
 namespace SysLog.Domine.Interfaces.Repositories;
 
@@ -10,5 +11,4 @@ public interface ILogRepository : IRepository<Log>
     /// Remove all logs along with their related entities.
     /// </summary>
     Task RemoveAllLogsWithPropertiesAsync();
-    Task<IEnumerable<Log>> GetPagedLogsAsync(int page, int pageSize);
-}
+    Task<PagedResult<Log>> GetPagedLogsAsync(int page, int pageSize);}

--- a/SysLog.Infraestructure/Repositories/LogRepository.cs
+++ b/SysLog.Infraestructure/Repositories/LogRepository.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using SysLog.Domine.Interfaces.Repositories;
 using SysLog.Repository.Data;
 using SysLog.Repository.Model;
+using SysLog.Shared;
 using Action = SysLog.Repository.Model.Action;
 
 namespace SysLog.Repository.Repositories;
@@ -41,14 +42,16 @@ TRUNCATE TABLE ""signatures"", ""logs_type"", ""actions"", ""interfaces"", ""pro
         await _dbContext.Database.ExecuteSqlRawAsync(sql);
     }
 
-    public async Task<IEnumerable<Log>> GetPagedLogsAsync(int page, int pageSize)
+    public async Task<PagedResult<Log>> GetPagedLogsAsync(int page, int pageSize)
     {
         if (page < 1)
             page = 1;
         if (pageSize < 1)
             pageSize = 1;
 
-        return await _dbContext.Set<Log>()
+        var totalItems = await _dbContext.Set<Log>().CountAsync();
+
+        var items = await _dbContext.Set<Log>()
             .OrderByDescending(log => log.DateTime)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
@@ -58,5 +61,12 @@ TRUNCATE TABLE ""signatures"", ""logs_type"", ""actions"", ""interfaces"", ""pro
             .Include(log => log.LogType)
                 .ThenInclude(lt => lt.Signature)
             .ToListAsync();
-    }
-}
+
+        return new PagedResult<Log>
+        {
+            Items = items,
+            TotalItems = totalItems,
+            Page = page,
+            PageSize = pageSize
+        };
+    }}

--- a/SysLog.Infraestructure/SysLog.Infraestructure.csproj
+++ b/SysLog.Infraestructure/SysLog.Infraestructure.csproj
@@ -7,10 +7,11 @@
         <RootNamespace>SysLog.Repository</RootNamespace>
     </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\SysLog.Application\SysLog.Application.csproj" />
-      <ProjectReference Include="..\SysLog.Domine\SysLog.Domine.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SysLog.Application\SysLog.Application.csproj" />
+    <ProjectReference Include="..\SysLog.Domine\SysLog.Domine.csproj" />
+    <ProjectReference Include="..\SysLog.Shared\SysLog.Shared.csproj" />
+  </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.2" />

--- a/SysLog.Shared/PagedResult.cs
+++ b/SysLog.Shared/PagedResult.cs
@@ -1,0 +1,9 @@
+namespace SysLog.Shared;
+
+public class PagedResult<T>
+{
+    public List<T> Items { get; set; } = [];
+    public int TotalItems { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `PagedResult<T>` DTO to represent paged responses
- implement pagination with total count on repository and service layers
- update API endpoint to return a paged result
- adjust client service and `Table.razor` to use new paged API
- add shared project reference for infrastructure

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9fcc1f1c83268b8afaddcff8f9d8