### PR TITLE
Add pagination support for backup logs

### DIFF
--- a/SysLog.Api/Controller/LogController.cs
+++ b/SysLog.Api/Controller/LogController.cs
@@ -63,14 +63,27 @@ public class LogController : ControllerBase
         return Ok(logs);
     }
 
+    [HttpGet("backup-paged")]
+    public async Task<ActionResult<PagedResult<LogDto>>> LoadBackupDayPaged([FromQuery] string day, [FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+    {
+        var logs = await _backupLoaderService.LoadBackupPagedAsync(day, page, pageSize);
+        return Ok(logs);
+    }
+
     [HttpGet("current")]
     public async Task<ActionResult<IEnumerable<LogDto>>> LoadCurrentLogs()
     {
         var logs = await _backupLoaderService.LoadCurrentLogsAsync();
         return Ok(logs);
     }
+
+    [HttpGet("current-paged")]
+    public async Task<ActionResult<PagedResult<LogDto>>> LoadCurrentLogsPaged([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+    {
+        var logs = await _backupLoaderService.LoadCurrentLogsPagedAsync(page, pageSize);
+        return Ok(logs);
+    }
     
     
     
-    
-}
+    }

--- a/SysLog.Application/Interfaces/Services/IBackupLoaderService.cs
+++ b/SysLog.Application/Interfaces/Services/IBackupLoaderService.cs
@@ -1,4 +1,5 @@
 using SysLog.Shared.ModelDto;
+using SysLog.Shared;
 
 namespace SysLog.Service.Interfaces.Services;
 
@@ -6,4 +7,14 @@ public interface IBackupLoaderService
 {
     Task<List<LogDto>> LoadBackupAsync(string day);
     Task<List<LogDto>> LoadCurrentLogsAsync();
+
+    /// <summary>
+    /// Load logs for a specific backup day using pagination.
+    /// </summary>
+    Task<PagedResult<LogDto>> LoadBackupPagedAsync(string day, int page, int pageSize);
+
+    /// <summary>
+    /// Load current logs through the backup pipeline using pagination.
+    /// </summary>
+    Task<PagedResult<LogDto>> LoadCurrentLogsPagedAsync(int page, int pageSize);
 }

--- a/SysLog.Application/Services/BackupLoaderService.cs
+++ b/SysLog.Application/Services/BackupLoaderService.cs
@@ -2,6 +2,7 @@ using SysLog.Domine.Interfaces.Repositories;
 using SysLog.Service.Interfaces.Services;
 using SysLog.Service.Mappers;
 using SysLog.Shared.ModelDto;
+using SysLog.Shared;
 
 namespace SysLog.Service.Services;
 
@@ -18,5 +19,29 @@ public class BackupLoaderService(IBackupLoaderRepository repository) : IBackupLo
     {
         var logs = await repository.LoadCurrentLogsAsync();
         return logs.Select(MapperLog.MapToLogDto).ToList();
+    }
+
+    public async Task<PagedResult<LogDto>> LoadBackupPagedAsync(string day, int page, int pageSize)
+    {
+        var result = await repository.LoadBackupPagedAsync(day, page, pageSize);
+        return new PagedResult<LogDto>
+        {
+            Items = result.Items.Select(MapperLog.MapToLogDto).ToList(),
+            TotalItems = result.TotalItems,
+            Page = result.Page,
+            PageSize = result.PageSize
+        };
+    }
+
+    public async Task<PagedResult<LogDto>> LoadCurrentLogsPagedAsync(int page, int pageSize)
+    {
+        var result = await repository.LoadCurrentLogsPagedAsync(page, pageSize);
+        return new PagedResult<LogDto>
+        {
+            Items = result.Items.Select(MapperLog.MapToLogDto).ToList(),
+            TotalItems = result.TotalItems,
+            Page = result.Page,
+            PageSize = result.PageSize
+        };
     }
 }

--- a/SysLog.Client/Pages/Table.razor
+++ b/SysLog.Client/Pages/Table.razor
@@ -107,6 +107,8 @@ else
     private bool _loading { get; set; }
     private int CurrentPage { get; set; } = 1;
     private int PageSize { get; set; } = 10;
+    private bool _isBackupView { get; set; } = false;
+    private string? _selectedDay;
 
     private bool _showAlert = false;
     private TaskResult _result { get; set; } = new();
@@ -128,12 +130,25 @@ else
     }
     
     
-        private async Task LoadLogs()
+    private async Task LoadLogs()
     {
         _loading = true;
         StateHasChanged();
-        
-        var result = await LogService.GetPagedLogs(CurrentPage, PageSize);
+
+        TaskResult<PagedResult<LogDto>> result;
+
+        if (_isBackupView && !string.IsNullOrEmpty(_selectedDay))
+        {
+            result = await BackupService.LoadBackupPaged(_selectedDay, CurrentPage, PageSize);
+        }
+        else if (_isBackupView)
+        {
+            result = await BackupService.LoadCurrentPaged(CurrentPage, PageSize);
+        }
+        else
+        {
+            result = await LogService.GetPagedLogs(CurrentPage, PageSize);
+        }
 
         if (result.IsSuccessful(out var paged))
         {
@@ -201,6 +216,8 @@ else
         if (clear)
         {
             _logs = _originalLogs;
+            _isBackupView = false;
+            _selectedDay = null;
             await LoadLogs();
         }
     }
@@ -209,13 +226,16 @@ else
     {
         _loading = true;
         StateHasChanged();
-        var result = await BackupService.LoadBackup(day);
-        if (result.IsSuccessful(out var logs))
+        _selectedDay = day;
+        _isBackupView = true;
+        CurrentPage = 1;
+
+        var result = await BackupService.LoadBackupPaged(day, CurrentPage, PageSize);
+        if (result.IsSuccessful(out var paged))
         {
-            _logs = logs;
-            _originalLogs = logs;
-            TotalLogs = logs.Count;
-            CurrentPage = 1;
+            _logs = paged.Items;
+            _originalLogs = paged.Items;
+            TotalLogs = paged.TotalItems;
         }
         else
         {
@@ -230,13 +250,16 @@ else
     {
         _loading = true;
         StateHasChanged();
-        var result = await BackupService.LoadCurrentLogs();
-        if (result.IsSuccessful(out var logs))
+        _isBackupView = false;
+        _selectedDay = null;
+        CurrentPage = 1;
+
+        var result = await BackupService.LoadCurrentPaged(CurrentPage, PageSize);
+        if (result.IsSuccessful(out var paged))
         {
-            _logs = logs;
-            _originalLogs = logs;
-            TotalLogs = logs.Count;
-            CurrentPage = 1;
+            _logs = paged.Items;
+            _originalLogs = paged.Items;
+            TotalLogs = paged.TotalItems;
         }
         else
         {
@@ -244,5 +267,4 @@ else
             _result = TaskResult.FromFailure(result.Message, result.Code, result.Details);
         }
         _loading = false;
-        StateHasChanged();
-    }}
+        StateHasChanged();    }}

--- a/SysLog.Client/Services/BackupService.cs
+++ b/SysLog.Client/Services/BackupService.cs
@@ -31,11 +31,27 @@ public class BackupService
         return TaskResult<List<LogDto>>.FromFailure(result?.Message ?? "Error");
     }
 
+    public async Task<TaskResult<PagedResult<LogDto>>> LoadBackupPaged(string day, int page, int pageSize)
+    {
+        var result = await _client.CallApiAsync<PagedResult<LogDto>>($"api/log/backup-paged?day={day}&page={page}&pageSize={pageSize}", "GET");
+        if (result != null && result.Value.IsSuccessful(out var logs))
+            return TaskResult<PagedResult<LogDto>>.FromData(logs);
+        return TaskResult<PagedResult<LogDto>>.FromFailure(result?.Message ?? "Error");
+    }
+
     public async Task<TaskResult<List<LogDto>>> LoadCurrentLogs()
     {
         var result = await _client.CallApiAsync<List<LogDto>>("api/log/current", "GET");
         if (result != null && result.Value.IsSuccessful(out var logs))
             return TaskResult<List<LogDto>>.FromData(logs);
         return TaskResult<List<LogDto>>.FromFailure(result?.Message ?? "Error");
+    }
+
+    public async Task<TaskResult<PagedResult<LogDto>>> LoadCurrentPaged(int page, int pageSize)
+    {
+        var result = await _client.CallApiAsync<PagedResult<LogDto>>($"api/log/current-paged?page={page}&pageSize={pageSize}", "GET");
+        if (result != null && result.Value.IsSuccessful(out var logs))
+            return TaskResult<PagedResult<LogDto>>.FromData(logs);
+        return TaskResult<PagedResult<LogDto>>.FromFailure(result?.Message ?? "Error");
     }
 }

--- a/SysLog.Domine/Interfaces/Repositories/IBackupLoaderRepository.cs
+++ b/SysLog.Domine/Interfaces/Repositories/IBackupLoaderRepository.cs
@@ -1,4 +1,5 @@
 using SysLog.Repository.Model;
+using SysLog.Shared;
 
 namespace SysLog.Domine.Interfaces.Repositories;
 
@@ -6,4 +7,14 @@ public interface IBackupLoaderRepository
 {
     Task<List<Log>> LoadBackupAsync(string day);
     Task<List<Log>> LoadCurrentLogsAsync();
+
+    /// <summary>
+    /// Load logs for a specific backup day with pagination.
+    /// </summary>
+    Task<PagedResult<Log>> LoadBackupPagedAsync(string day, int page, int pageSize);
+
+    /// <summary>
+    /// Load current logs using the backup loader pipeline with pagination.
+    /// </summary>
+    Task<PagedResult<Log>> LoadCurrentLogsPagedAsync(int page, int pageSize);
 }

--- a/SysLog.Infraestructure/Repositories/BackupLoaderRepository.cs
+++ b/SysLog.Infraestructure/Repositories/BackupLoaderRepository.cs
@@ -4,6 +4,7 @@ using SysLog.Domine.Interfaces.Repositories;
 using SysLog.Repository.Data;
 using SysLog.Repository.Data.BackupDbContext;
 using SysLog.Repository.Model;
+using SysLog.Shared;
 
 namespace SysLog.Repository.Repositories;
 
@@ -49,6 +50,77 @@ public class BackupLoaderRepository : IBackupLoaderRepository
         await conn.CloseAsync();
 
         return await GetLogsFromMainAsync();
+    }
+
+    public async Task<PagedResult<Log>> LoadBackupPagedAsync(string day, int page, int pageSize)
+    {
+        await using var conn = (NpgsqlConnection)_backupContext.Database.GetDbConnection();
+        await conn.OpenAsync();
+        await CleanupAsync(conn);
+
+        var backups = await _backupContext.BackupFile
+            .Where(b => b.FileName.StartsWith(day))
+            .OrderBy(b => b.FileName)
+            .ToListAsync();
+
+        foreach (var backup in backups)
+        {
+            var scriptPath = Path.Combine(backup.PathFile, backup.FileName);
+            var sql = await File.ReadAllTextAsync(scriptPath);
+
+            await ExecuteSqlScriptAsync(conn, sql);
+        }
+
+        await conn.CloseAsync();
+
+        var totalItems = await _backupContext.Logs.CountAsync();
+        var items = await _backupContext.Logs
+            .Include(l => l.Protocol)
+            .Include(l => l.Action)
+            .Include(l => l.Interface)
+            .Include(l => l.LogType)
+                .ThenInclude(lt => lt.Signature)
+            .OrderByDescending(l => l.DateTime)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+
+        return new PagedResult<Log>
+        {
+            Items = items,
+            TotalItems = totalItems,
+            Page = page,
+            PageSize = pageSize
+        };
+    }
+
+    public async Task<PagedResult<Log>> LoadCurrentLogsPagedAsync(int page, int pageSize)
+    {
+        await using var conn = (NpgsqlConnection)_backupContext.Database.GetDbConnection();
+        await conn.OpenAsync();
+        await CleanupAsync(conn);
+        await conn.CloseAsync();
+
+        var totalItems = await _logContext.Logs.CountAsync();
+
+        var items = await _logContext.Logs
+            .Include(l => l.Protocol)
+            .Include(l => l.Action)
+            .Include(l => l.Interface)
+            .Include(l => l.LogType)
+                .ThenInclude(lt => lt.Signature)
+            .OrderByDescending(l => l.DateTime)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+
+        return new PagedResult<Log>
+        {
+            Items = items,
+            TotalItems = totalItems,
+            Page = page,
+            PageSize = pageSize
+        };
     }
 
     private static async Task ExecuteSqlScriptAsync(NpgsqlConnection connection, string script)


### PR DESCRIPTION
## Summary
- implement paged log loading for backups
- expose new API endpoints for `backup-paged` and `current-paged`
- update service layer and repository to handle paged queries
- add client methods for paginated backups
- update Table UI to paginate backup logs

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da8f73fa88326837da64bd5526a09