### PR TITLE
Add log search and filter component

### DIFF
--- a/SysLog.Api/Controller/LogController.cs
+++ b/SysLog.Api/Controller/LogController.cs
@@ -47,6 +47,13 @@ public class LogController : ControllerBase
         var logs = await _logService.GetPagedLogsAsync(page, pageSize);
         return Ok(logs);
     }
+
+    [HttpGet("search")]
+    public async Task<ActionResult<PagedResult<LogDto>>> Search([FromQuery] string? property, [FromQuery] string? term, [FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+    {
+        var logs = await _logService.SearchLogsAsync(property, term, page, pageSize);
+        return Ok(logs);
+    }
     
 
     [HttpGet("days")]

--- a/SysLog.Application/Interfaces/Services/ILogService.cs
+++ b/SysLog.Application/Interfaces/Services/ILogService.cs
@@ -5,10 +5,12 @@ namespace SysLog.Service.Interfaces.Services;
 
 public interface ILogService : IServiceDto<LogDto>
 {
-    public Task<LogDto> GetLastLogAsync();
+    Task<LogDto> GetLastLogAsync();
     Task RemoveAllLogsAsync();
     /// <summary>
     /// Remove logs and their related properties after backup.
     /// </summary>
     Task RemoveAllLogsWithPropertiesAsync();
-    Task<PagedResult<LogDto>> GetPagedLogsAsync(int page, int pageSize);}
+    Task<PagedResult<LogDto>> GetPagedLogsAsync(int page, int pageSize);
+    Task<PagedResult<LogDto>> SearchLogsAsync(string? property, string? term, int page, int pageSize);
+}

--- a/SysLog.Application/Services/LogService.cs
+++ b/SysLog.Application/Services/LogService.cs
@@ -41,4 +41,17 @@ public class LogService(ILogRepository repository) : Service<LogDto,Log>(reposit
             Page = result.Page,
             PageSize = result.PageSize
         };
-    }}
+    }
+
+    public async Task<PagedResult<LogDto>> SearchLogsAsync(string? property, string? term, int page, int pageSize)
+    {
+        var result = await repository.SearchLogsAsync(property, term, page, pageSize);
+        return new PagedResult<LogDto>
+        {
+            Items = result.Items.Select(MapperLog.MapToLogDto).ToList(),
+            TotalItems = result.TotalItems,
+            Page = result.Page,
+            PageSize = result.PageSize
+        };
+    }
+}

--- a/SysLog.Client/Components/LogSearchFilter.razor
+++ b/SysLog.Client/Components/LogSearchFilter.razor
@@ -1,0 +1,44 @@
+<div class="flex flex-col md:flex-row gap-2 mb-4">
+    <InputText class="input input-bordered w-full md:w-1/3" placeholder="Buscar" @bind-Value="SearchTerm" @oninput="HandleChanged" />
+    <select class="select select-bordered w-full md:w-1/4" @bind="SelectedProperty" @onchange="HandleChanged">
+        <option value="">-- Propiedad --</option>
+        @foreach (var p in Properties)
+        {
+            <option value="@p">@p</option>
+        }
+    </select>
+    <button type="button" class="btn btn-neutral md:w-auto" @onclick="Clear">Limpiar</button>
+</div>
+
+@code {
+    [Parameter]
+    public string SearchTerm { get; set; } = string.Empty;
+
+    [Parameter]
+    public EventCallback<string> SearchTermChanged { get; set; }
+
+    [Parameter]
+    public string SelectedProperty { get; set; } = string.Empty;
+
+    [Parameter]
+    public EventCallback<string> SelectedPropertyChanged { get; set; }
+
+    [Parameter]
+    public EventCallback OnFilterChanged { get; set; }
+
+    private IEnumerable<string> Properties { get; set; } = typeof(LogDto).GetProperties().Select(p => p.Name);
+
+    private async Task HandleChanged()
+    {
+        await SearchTermChanged.InvokeAsync(SearchTerm);
+        await SelectedPropertyChanged.InvokeAsync(SelectedProperty);
+        await OnFilterChanged.InvokeAsync();
+    }
+
+    private async Task Clear()
+    {
+        SearchTerm = string.Empty;
+        SelectedProperty = string.Empty;
+        await HandleChanged();
+    }
+}

--- a/SysLog.Client/Pages/LogList.razor
+++ b/SysLog.Client/Pages/LogList.razor
@@ -1,4 +1,4 @@
-﻿@page "/table"
+﻿@page "/logs"
 @using SysLog.Client.Services
 @using SysLog.Shared
 @using SysLog.Shared.ModelDto
@@ -30,6 +30,7 @@
             <h6 class="m-0 font-weight-bold text-primary">Tabla de logs registrados</h6>
         </div>
         <div class="card-body">
+            <LogSearchFilter @bind-SearchTerm="searchTerm" @bind-SelectedProperty="selectedProperty" OnFilterChanged="ApplyFilters" />
             <div class="table-responsive">
                 <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
                     <thead>
@@ -112,6 +113,9 @@ else
 
     private bool _showAlert = false;
     private TaskResult _result { get; set; } = new();
+
+    private string searchTerm = string.Empty;
+    private string selectedProperty = string.Empty;
 
     protected override async Task OnInitializedAsync()
     {
@@ -208,6 +212,40 @@ else
             (l.LogType.Signature is not null && l.LogType.Signature.Message.Contains(searchLog,StringComparison.OrdinalIgnoreCase)) ||
             (l.Interface is not null && l.Interface.Name.Contains(searchLog,StringComparison.OrdinalIgnoreCase))
         ).ToList();
+        StateHasChanged();
+    }
+
+    private void ApplyFilters()
+    {
+        if (string.IsNullOrWhiteSpace(searchTerm))
+        {
+            _logs = _originalLogs;
+        }
+        else if (string.IsNullOrWhiteSpace(selectedProperty))
+        {
+            _logs = _originalLogs.Where(l =>
+                (l.Action?.AcctionName?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (l.IpOut?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (l.IpDestiny?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (l.Interface?.Name?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (l.Protocol?.Name?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (l.LogType?.TypeName?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                (l.LogType?.Signature?.Message?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                l.DateTime.ToString("MM/dd/yyyy").Contains(searchTerm, StringComparison.OrdinalIgnoreCase)
+            ).ToList();
+        }
+        else
+        {
+            var prop = typeof(LogDto).GetProperty(selectedProperty);
+            if (prop is not null)
+            {
+                _logs = _originalLogs.Where(l =>
+                {
+                    var value = prop.GetValue(l);
+                    return value != null && value.ToString().Contains(searchTerm, StringComparison.OrdinalIgnoreCase);
+                }).ToList();
+            }
+        }
         StateHasChanged();
     }
 

--- a/SysLog.Client/Pages/LogList.razor
+++ b/SysLog.Client/Pages/LogList.razor
@@ -215,37 +215,35 @@ else
         StateHasChanged();
     }
 
-    private void ApplyFilters()
+    private async Task ApplyFilters()
     {
-        if (string.IsNullOrWhiteSpace(searchTerm))
+        _loading = true;
+        StateHasChanged();
+
+        TaskResult<PagedResult<LogDto>> result;
+
+        if (string.IsNullOrWhiteSpace(searchTerm) && string.IsNullOrWhiteSpace(selectedProperty))
         {
-            _logs = _originalLogs;
-        }
-        else if (string.IsNullOrWhiteSpace(selectedProperty))
-        {
-            _logs = _originalLogs.Where(l =>
-                (l.Action?.AcctionName?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (l.IpOut?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (l.IpDestiny?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (l.Interface?.Name?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (l.Protocol?.Name?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (l.LogType?.TypeName?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                (l.LogType?.Signature?.Message?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                l.DateTime.ToString("MM/dd/yyyy").Contains(searchTerm, StringComparison.OrdinalIgnoreCase)
-            ).ToList();
+            result = await LogService.GetPagedLogs(CurrentPage, PageSize);
         }
         else
         {
-            var prop = typeof(LogDto).GetProperty(selectedProperty);
-            if (prop is not null)
-            {
-                _logs = _originalLogs.Where(l =>
-                {
-                    var value = prop.GetValue(l);
-                    return value != null && value.ToString().Contains(searchTerm, StringComparison.OrdinalIgnoreCase);
-                }).ToList();
-            }
+            result = await LogService.SearchLogs(selectedProperty, searchTerm, CurrentPage, PageSize);
         }
+
+        if (result.IsSuccessful(out var paged))
+        {
+            _logs = paged.Items;
+            _originalLogs = paged.Items;
+            TotalLogs = paged.TotalItems;
+        }
+        else
+        {
+            _showAlert = true;
+            _result = TaskResult.FromFailure(result.Message, result.Code, result.Details);
+        }
+
+        _loading = false;
         StateHasChanged();
     }
 
@@ -305,4 +303,6 @@ else
             _result = TaskResult.FromFailure(result.Message, result.Code, result.Details);
         }
         _loading = false;
-        StateHasChanged();    }}
+        StateHasChanged();
+    }
+}

--- a/SysLog.Client/Services/LogService.cs
+++ b/SysLog.Client/Services/LogService.cs
@@ -25,6 +25,18 @@ public class LogService
         }
         return TaskResult<PagedResult<LogDto>>.FromFailure(result.Value.Message, result.Value.Code, result.Value.Details);
     }
+
+    public async Task<TaskResult<PagedResult<LogDto>>> SearchLogs(string? property, string? term, int page, int pageSize)
+    {
+        var url = $"api/log/search?property={property}&term={term}&page={page}&pageSize={pageSize}";
+        var result = await Client.CallApiAsync<PagedResult<LogDto>>(url, "GET");
+
+        if (result.Value.IsSuccessful(out var data))
+        {
+            return TaskResult<PagedResult<LogDto>>.FromData(data);
+        }
+        return TaskResult<PagedResult<LogDto>>.FromFailure(result.Value.Message, result.Value.Code, result.Value.Details);
+    }
     
     
     

--- a/SysLog.Domine/Interfaces/Repositories/ILogRepository.cs
+++ b/SysLog.Domine/Interfaces/Repositories/ILogRepository.cs
@@ -11,4 +11,6 @@ public interface ILogRepository : IRepository<Log>
     /// Remove all logs along with their related entities.
     /// </summary>
     Task RemoveAllLogsWithPropertiesAsync();
-    Task<PagedResult<Log>> GetPagedLogsAsync(int page, int pageSize);}
+    Task<PagedResult<Log>> GetPagedLogsAsync(int page, int pageSize);
+    Task<PagedResult<Log>> SearchLogsAsync(string? property, string? term, int page, int pageSize);
+}

--- a/SysLog.Infraestructure/Repositories/LogRepository.cs
+++ b/SysLog.Infraestructure/Repositories/LogRepository.cs
@@ -69,4 +69,67 @@ TRUNCATE TABLE ""signatures"", ""logs_type"", ""actions"", ""interfaces"", ""pro
             Page = page,
             PageSize = pageSize
         };
-    }}
+    }
+
+    public async Task<PagedResult<Log>> SearchLogsAsync(string? property, string? term, int page, int pageSize)
+    {
+        if (page < 1)
+            page = 1;
+        if (pageSize < 1)
+            pageSize = 1;
+
+        var query = _dbContext.Set<Log>()
+            .Include(l => l.Protocol)
+            .Include(l => l.Action)
+            .Include(l => l.Interface)
+            .Include(l => l.LogType)
+                .ThenInclude(lt => lt.Signature)
+            .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(term))
+        {
+            term = term.ToLower();
+            if (!string.IsNullOrWhiteSpace(property))
+            {
+                query = property switch
+                {
+                    "IpOut" => query.Where(l => l.IpOut.ToLower().Contains(term)),
+                    "IpDestiny" => query.Where(l => l.IpDestiny.ToLower().Contains(term)),
+                    "Protocol" => query.Where(l => l.Protocol.Name.ToLower().Contains(term)),
+                    "Action" => query.Where(l => l.Action.AcctionName.ToLower().Contains(term)),
+                    "Interface" => query.Where(l => l.Interface.Name.ToLower().Contains(term)),
+                    "LogType" => query.Where(l => l.LogType.TypeName.ToLower().Contains(term)),
+                    "DateTime" => query.Where(l => l.DateTime.ToString().ToLower().Contains(term)),
+                    _ => query.Where(l => l.LogType.Signature.Message.ToLower().Contains(term))
+                };
+            }
+            else
+            {
+                query = query.Where(l =>
+                    l.IpOut.ToLower().Contains(term) ||
+                    l.IpDestiny.ToLower().Contains(term) ||
+                    l.Protocol.Name.ToLower().Contains(term) ||
+                    l.Action.AcctionName.ToLower().Contains(term) ||
+                    l.Interface.Name.ToLower().Contains(term) ||
+                    l.LogType.TypeName.ToLower().Contains(term) ||
+                    l.LogType.Signature.Message.ToLower().Contains(term) ||
+                    l.DateTime.ToString().ToLower().Contains(term)
+                );
+            }
+        }
+
+        var totalItems = await query.CountAsync();
+        var items = await query.OrderByDescending(l => l.DateTime)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+
+        return new PagedResult<Log>
+        {
+            Items = items,
+            TotalItems = totalItems,
+            Page = page,
+            PageSize = pageSize
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- rename `Table.razor` to `LogList.razor`
- add `LogSearchFilter` component for searching and filtering logs
- integrate the filter into the log list page

## Testing
- `dotnet build SysLog.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e47db16e48326bb5745ff05e2577f